### PR TITLE
Add context to client

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lazyledger/lazyledger-core/libs/log"
@@ -22,7 +23,7 @@ type Node struct {
 	client *p2p.Client
 }
 
-func NewNode(conf config.NodeConfig, nodeKey crypto.PrivKey, clientCreator proxy.ClientCreator, logger log.Logger) (*Node, error) {
+func NewNode(ctx context.Context, conf config.NodeConfig, nodeKey crypto.PrivKey, clientCreator proxy.ClientCreator, logger log.Logger) (*Node, error) {
 	proxyApp := proxy.NewAppConns(clientCreator)
 	proxyApp.SetLogger(logger.With("module", "proxy"))
 	if err := proxyApp.Start(); err != nil {
@@ -35,7 +36,7 @@ func NewNode(conf config.NodeConfig, nodeKey crypto.PrivKey, clientCreator proxy
 		return nil, err
 	}
 
-	client, err := p2p.NewClient(conf.P2P, nodeKey, logger.With("module", "p2p"))
+	client, err := p2p.NewClient(ctx, conf.P2P, nodeKey, logger.With("module", "p2p"))
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/client_test.go
+++ b/p2p/client_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"context"
 	"crypto/rand"
 	"strings"
 	"testing"
@@ -33,7 +34,7 @@ func (t *TestLogger) Error(msg string, keyvals ...interface{}) {
 
 func TestClientStartup(t *testing.T) {
 	privKey, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	client, err := NewClient(config.P2PConfig{}, privKey, &TestLogger{t})
+	client, err := NewClient(context.Background(), config.P2PConfig{}, privKey, &TestLogger{t})
 	assert := assert.New(t)
 	assert.NoError(err)
 	assert.NotNil(client)
@@ -60,19 +61,19 @@ func TestBootstrapping(t *testing.T) {
 	require.NotEmpty(cid2)
 
 	// client1 has no seeds
-	client1, err := NewClient(config.P2PConfig{ListenAddress: "127.0.0.1:7676"}, privKey1, logger)
+	client1, err := NewClient(context.Background(), config.P2PConfig{ListenAddress: "127.0.0.1:7676"}, privKey1, logger)
 	require.NoError(err)
 	require.NotNil(client1)
 
 	// client2 will use client1 as predefined seed
-	client2, err := NewClient(config.P2PConfig{
+	client2, err := NewClient(context.Background(), config.P2PConfig{
 		ListenAddress: "127.0.0.1:7677",
 		Seeds:         cid1.Pretty() + "@127.0.0.1:7676",
 	}, privKey2, logger)
 	require.NoError(err)
 
 	// client3 will use clien1 and client2 as seeds
-	client3, err := NewClient(config.P2PConfig{
+	client3, err := NewClient(context.Background(), config.P2PConfig{
 		ListenAddress: "127.0.0.1:7678",
 		Seeds:         cid1.Pretty() + "@127.0.0.1:7676" + "," + cid2.Pretty() + "@127.0.0.1:7677",
 	}, privKey3, logger)


### PR DESCRIPTION
To enable control over client life-cycle, we need a context. It's also passed to libp2p layer.