### PR TITLE
Refactoring of P2P unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.11.1
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/stretchr/testify v1.7.0
+	go.uber.org/multierr v1.5.0
 )

--- a/p2p/client_test.go
+++ b/p2p/client_test.go
@@ -71,7 +71,9 @@ func TestBootstrapping(t *testing.T) {
 	assert := assert.New(t)
 	logger := &TestLogger{t}
 
-	clients := startTestNetwork(t, 4, map[int][]int{
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	clients := startTestNetwork(ctx, t, 4, map[int][]int{
 		1: []int{0},
 		2: []int{0, 1},
 		3: []int{0},
@@ -89,7 +91,9 @@ func TestDiscovery(t *testing.T) {
 	assert := assert.New(t)
 	logger := &TestLogger{t}
 
-	clients := startTestNetwork(t, 5, map[int][]int{
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	clients := startTestNetwork(ctx, t, 5, map[int][]int{
 		1: []int{0},
 		2: []int{0},
 		3: []int{1},

--- a/p2p/client_test.go
+++ b/p2p/client_test.go
@@ -62,7 +62,6 @@ func TestClientStartup(t *testing.T) {
 	err = client.Start(context.Background())
 	defer client.Close()
 	assert.NoError(err)
-
 }
 
 func TestBootstrapping(t *testing.T) {
@@ -70,171 +69,51 @@ func TestBootstrapping(t *testing.T) {
 	//log.SetDebugLogging()
 
 	assert := assert.New(t)
-	require := require.New(t)
 	logger := &TestLogger{t}
 
-	privKey1, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	privKey2, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	privKey3, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	privKey4, _, _ := crypto.GenerateEd25519Key(rand.Reader)
+	clients := makeTestNetowork(t, 4, map[int][]int{
+		1: []int{0},
+		2: []int{0, 1},
+		3: []int{0},
+	}, logger)
 
-	cid1, err := peer.IDFromPrivateKey(privKey1)
-	require.NoError(err)
-	require.NotEmpty(cid1)
-
-	cid2, err := peer.IDFromPrivateKey(privKey2)
-	require.NoError(err)
-	require.NotEmpty(cid2)
-
-	// client1 has no seeds
-	client1, err := NewClient(config.P2PConfig{ListenAddress: "/ip4/0.0.0.0/tcp/7676"}, privKey1, logger)
-	require.NoError(err)
-	require.NotNil(client1)
-
-	// client2 will use client1 as predefined seed
-	client2, err := NewClient(config.P2PConfig{
-		ListenAddress: "/ip4/127.0.0.1/tcp/7677",
-		Seeds:         "/ip4/127.0.0.1/tcp/7676/p2p/" + cid1.String(),
-	}, privKey2, logger)
-	require.NoError(err)
-
-	// client3 will use clien1 and client2 as seeds
-	client3, err := NewClient(config.P2PConfig{
-		ListenAddress: "/ip4/127.0.0.1/tcp/7678",
-		Seeds:         "/ip4/127.0.0.1/tcp/7676/p2p/" + cid1.String() + ",/ip4/127.0.0.1/tcp/7677/p2p/" + cid2.String(),
-	}, privKey3, logger)
-	require.NoError(err)
-
-	// client4 will use clien1 as seed
-	client4, err := NewClient(config.P2PConfig{
-		ListenAddress: "/ip4/127.0.0.1/tcp/7679",
-		Seeds:         "/ip4/127.0.0.1/tcp/7676/p2p/" + cid1.String(),
-	}, privKey4, logger)
-	require.NoError(err)
-
-	err = client1.Start(context.Background())
-	defer client1.Close()
-	assert.NoError(err)
-
-	err = client2.Start(context.Background())
-	defer client2.Close()
-	assert.NoError(err)
-
-	err = client3.Start(context.Background())
-	defer client3.Close()
-	assert.NoError(err)
-
-	err = client4.Start(context.Background())
-	defer client4.Close()
+	err := clients.Start(context.Background())
+	defer clients.Close()
 	assert.NoError(err)
 
 	// wait for clients to finish refreshing routing tables
-	<-client1.dht.RefreshRoutingTable()
-	<-client2.dht.RefreshRoutingTable()
-	<-client3.dht.RefreshRoutingTable()
-	<-client4.dht.RefreshRoutingTable()
+	clients.WaitForDHT()
 
-	assert.Equal(3, len(client1.host.Network().Peers()))
-	assert.Equal(3, len(client2.host.Network().Peers()))
-	assert.Equal(3, len(client3.host.Network().Peers()))
-	assert.Equal(3, len(client4.host.Network().Peers()))
+	for _, client := range clients {
+		assert.Equal(3, len(client.host.Network().Peers()))
+	}
 }
 
 func TestDiscovery(t *testing.T) {
 	assert := assert.New(t)
-	require := require.New(t)
 	logger := &TestLogger{t}
 
-	// TODO: create helper function to create "connected" network
-	privKey1, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	privKey2, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	privKey3, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	privKey4, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	privKey5, _, _ := crypto.GenerateEd25519Key(rand.Reader)
+	clients := makeTestNetowork(t, 5, map[int][]int{
+		1: []int{0},
+		2: []int{0},
+		3: []int{1},
+		4: []int{2},
+	}, logger)
 
-	cid1, err := peer.IDFromPrivateKey(privKey1)
-	require.NoError(err)
-	require.NotEmpty(cid1)
+	clients[1].chainID = "ORU2"
+	clients[2].chainID = "ORU2"
+	clients[3].chainID = "ORU1"
+	clients[4].chainID = "ORU1"
 
-	cid2, err := peer.IDFromPrivateKey(privKey2)
-	require.NoError(err)
-	require.NotEmpty(cid2)
-
-	cid3, err := peer.IDFromPrivateKey(privKey3)
-	require.NoError(err)
-	require.NotEmpty(cid2)
-
-	// client1 has no seeds
-	client1, err := NewClient(config.P2PConfig{ListenAddress: "/ip4/0.0.0.0/tcp/7676"}, privKey1, logger)
-	require.NoError(err)
-	require.NotNil(client1)
-
-	// client2 will use client1 as predefined seed
-	client2, err := NewClient(config.P2PConfig{
-		ListenAddress: "/ip4/127.0.0.1/tcp/7677",
-		Seeds:         "/ip4/127.0.0.1/tcp/7676/p2p/" + cid1.String(),
-	}, privKey2, logger)
-	require.NoError(err)
-
-	// client3 will use clien1 as predefined seed
-	client3, err := NewClient(config.P2PConfig{
-		ListenAddress: "/ip4/127.0.0.1/tcp/7678",
-		Seeds:         "/ip4/127.0.0.1/tcp/7676/p2p/" + cid1.String(),
-	}, privKey3, logger)
-	require.NoError(err)
-
-	// client4 will use clien2 as seed
-	client4, err := NewClient(config.P2PConfig{
-		ListenAddress: "/ip4/127.0.0.1/tcp/7679",
-		Seeds:         "/ip4/127.0.0.1/tcp/7677/p2p/" + cid2.String(),
-	}, privKey4, logger)
-	require.NoError(err)
-
-	// client5 will use clien2 as seed
-	client5, err := NewClient(config.P2PConfig{
-		ListenAddress: "/ip4/127.0.0.1/tcp/7680",
-		Seeds:         "/ip4/127.0.0.1/tcp/7678/p2p/" + cid3.String(),
-	}, privKey5, logger)
-	require.NoError(err)
-
-	client2.chainID = "ORU2"
-	client3.chainID = "ORU2"
-	client4.chainID = "ORU1"
-	client5.chainID = "ORU1"
-
-	err = client1.Start(context.Background())
-	defer client1.Close()
-	assert.NoError(err)
-
-	err = client2.Start(context.Background())
-	defer client2.Close()
-	assert.NoError(err)
-
-	err = client3.Start(context.Background())
-	defer client3.Close()
-	assert.NoError(err)
-
-	err = client4.Start(context.Background())
-	defer client4.Close()
-	assert.NoError(err)
-
-	err = client4.Start(context.Background())
-	defer client4.Close()
-	assert.NoError(err)
-
-	err = client5.Start(context.Background())
-	defer client5.Close()
+	err := clients.Start(context.Background())
+	defer clients.Close()
 	assert.NoError(err)
 
 	// wait for clients to finish refreshing routing tables
-	<-client1.dht.RefreshRoutingTable()
-	<-client2.dht.RefreshRoutingTable()
-	<-client3.dht.RefreshRoutingTable()
-	<-client4.dht.RefreshRoutingTable()
-	<-client5.dht.RefreshRoutingTable()
+	clients.WaitForDHT()
 
-	assert.Contains(client4.host.Network().Peers(), client5.host.ID())
-	assert.Contains(client5.host.Network().Peers(), client4.host.ID())
+	assert.Contains(clients[3].host.Network().Peers(), clients[4].host.ID())
+	assert.Contains(clients[4].host.Network().Peers(), clients[3].host.ID())
 }
 
 func TestSeedStringParsing(t *testing.T) {

--- a/p2p/client_test.go
+++ b/p2p/client_test.go
@@ -71,15 +71,11 @@ func TestBootstrapping(t *testing.T) {
 	assert := assert.New(t)
 	logger := &TestLogger{t}
 
-	clients := makeTestNetowork(t, 4, map[int][]int{
+	clients := startTestNetwork(t, 4, map[int][]int{
 		1: []int{0},
 		2: []int{0, 1},
 		3: []int{0},
 	}, logger)
-
-	err := clients.Start(context.Background())
-	defer clients.Close()
-	assert.NoError(err)
 
 	// wait for clients to finish refreshing routing tables
 	clients.WaitForDHT()
@@ -93,7 +89,7 @@ func TestDiscovery(t *testing.T) {
 	assert := assert.New(t)
 	logger := &TestLogger{t}
 
-	clients := makeTestNetowork(t, 5, map[int][]int{
+	clients := startTestNetwork(t, 5, map[int][]int{
 		1: []int{0},
 		2: []int{0},
 		3: []int{1},
@@ -104,10 +100,6 @@ func TestDiscovery(t *testing.T) {
 	clients[2].chainID = "ORU2"
 	clients[3].chainID = "ORU1"
 	clients[4].chainID = "ORU1"
-
-	err := clients.Start(context.Background())
-	defer clients.Close()
-	assert.NoError(err)
 
 	// wait for clients to finish refreshing routing tables
 	clients.WaitForDHT()

--- a/p2p/utils_test.go
+++ b/p2p/utils_test.go
@@ -1,0 +1,81 @@
+package p2p
+
+import (
+	"context"
+	"crypto/rand"
+	"strconv"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
+
+	"github.com/lazyledger/optimint/config"
+	"github.com/lazyledger/optimint/log"
+)
+
+type testNet []*Client
+
+func (tn testNet) Start(ctx context.Context) (err error) {
+	for i := range tn {
+		err = multierr.Append(err, tn[i].Start(ctx))
+	}
+	return
+}
+
+func (tn testNet) Close() (err error) {
+	for i := range tn {
+		err = multierr.Append(err, tn[i].Close())
+	}
+	return
+}
+
+func (tn testNet) WaitForDHT() {
+	for i := range tn {
+		<-tn[i].dht.RefreshRoutingTable()
+	}
+}
+
+func makeTestNetowork(t *testing.T, n int, conns map[int][]int, logger log.Logger) testNet {
+	t.Helper()
+	require := require.New(t)
+
+	basePort := 8000
+	getAddr := func(i int) string {
+		return "/ip4/127.0.0.1/tcp/" + strconv.Itoa(basePort+i)
+	}
+
+	privKeys := make([]crypto.PrivKey, n)
+	cids := make([]peer.ID, n)
+	for i := 0; i < n; i++ {
+		privKeys[i], _, _ = crypto.GenerateEd25519Key(rand.Reader)
+		cids[i], _ = peer.IDFromPrivateKey(privKeys[i])
+	}
+
+	// prepare seed node lists
+	seeds := make([]string, n)
+	for src, dsts := range conns {
+		require.Less(src, n)
+		for _, dst := range dsts {
+			require.Less(dst, n)
+			seeds[src] += getAddr(dst) + "/p2p/" + cids[dst].Pretty() + ","
+		}
+
+	}
+
+	clients := make([]*Client, n)
+	for i := 0; i < n; i++ {
+		client, err := NewClient(config.P2PConfig{
+			Seeds:         seeds[i],
+			ListenAddress: getAddr(i)},
+			privKeys[i],
+			logger)
+		require.NoError(err)
+		require.NotNil(client)
+
+		clients[i] = client
+	}
+
+	return clients
+}

--- a/p2p/utils_test.go
+++ b/p2p/utils_test.go
@@ -27,11 +27,11 @@ func (tn testNet) WaitForDHT() {
 	}
 }
 
-func startTestNetwork(t *testing.T, n int, conns map[int][]int, logger log.Logger) testNet {
+func startTestNetwork(ctx context.Context, t *testing.T, n int, conns map[int][]int, logger log.Logger) testNet {
 	t.Helper()
 	require := require.New(t)
 
-	mnet, err := mocknet.FullMeshLinked(context.Background(), n)
+	mnet, err := mocknet.FullMeshLinked(ctx, n)
 	require.NoError(err)
 
 	// prepare seed node lists
@@ -58,7 +58,7 @@ func startTestNetwork(t *testing.T, n int, conns map[int][]int, logger log.Logge
 	}
 
 	for i, c := range clients {
-		c.startWithHost(context.Background(), mnet.Hosts()[i])
+		c.startWithHost(ctx, mnet.Hosts()[i])
 	}
 
 	return clients


### PR DESCRIPTION
Refactoring of P2P layer tests.

- [x] replace manual creation of clients with some "factory" function
- [x] use libp2p mock network

Resolves #26, #27.